### PR TITLE
feat(workflow): add conventional commit check on pull requests

### DIFF
--- a/.github/workflows/conventional-commit-check.yaml
+++ b/.github/workflows/conventional-commit-check.yaml
@@ -1,0 +1,11 @@
+on:
+    pull_request:
+        types: [opened, edited, synchronize]
+
+jobs:
+    check_conventional_commit:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: webiny/action-conventional-commits@v1.0.3


### PR DESCRIPTION
## What?
A new github workflow for checking the utilization of conventional commits in the pull request before merging any changes into any target branch.

## Why?
This was added to ensure consistency throughout development, and avoid any possible future human errors.

## How?
A new `.yaml` file was added in the `.github/workflows` directory which should automatically check for the utilization of conventional commits at any update of the PR, the actual verification was done using an already available [github action](https://github.com/marketplace/actions/conventional-commits-check)

## Testing?
For testing you can investigate the actions from the PR itself, you should see a check for using the conventional check.

## Screenshots (optional)

> Successfully validating the conventional commit

<img width="1479" height="671" alt="image" src="https://github.com/user-attachments/assets/66897a99-2ce2-4521-ae80-82de555357ec" />

> Successfully invalidating the unconventional commit through another [pull request](https://github.com/eduard-balamatiuc/faf-pad-ghost-hunters/pull/2)

<img width="1479" height="594" alt="image" src="https://github.com/user-attachments/assets/3f531cb6-c964-4881-a465-a92bdb6deeb1" />



## Anything Else?
Nothing to add