### PR TITLE
feat(workflow): add gitflow convention branch naming check

### DIFF
--- a/.github/workflows/gitflow-branch-naming-check.yaml
+++ b/.github/workflows/gitflow-branch-naming-check.yaml
@@ -1,0 +1,24 @@
+on:
+    pull_request:
+        types: [opened, edited, synchronize]
+
+jobs:
+    gitflow_convention_branch_naming_check:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - run: |
+                # The branch name is available in the 'github.head_ref' context variable
+                BRANCH_NAME="${{ github.head_ref }}"
+                
+                REGEX="^(main|develop|((feature|bugfix|release|hotfix|support)\/[a-zA-Z0-9._-]+))$"
+
+                if [[ $BRANCH_NAME =~ $REGEX ]]; then
+                    echo "Branch name '$BRANCH_NAME' is valid according to GitFlow."
+                    exit 0
+                else
+                    echo "Error: Branch name '$BRANCH_NAME' does not follow GitFlow conventions."
+                    echo "Valid branch names are 'main', 'develop', or prefixed with 'feature/', 'bugfix/', 'release/', 'hotfix/', or 'support/'."
+                    exit 1
+                fi


### PR DESCRIPTION
## What?
Another Github workflow for ensuring that the gitflow branch naming convention defined by the team will be followed through each pull reuquest.

## Why?
This workflow will enable us to reduce human error, and prevent any possible mistakes during the development process.

## How?
I added a new file in the `.github/workflows` directory specifically targeted for this task with an inside bash script that checks directly through a REGEX if the naming convention is followed

## Testing?
You should be able to see a new check run on each PR, including this one

## Screenshots (optional)
-

## Anything Else?
Nothing to add