### PR TITLE
feat: add pull_request_template in github folder

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## What?
+[what exactly did you do in this PR]
+
+## Why?
+[why was this done in the first place]
+
+## How?
+[how did you implement it]
+
+## Testing?
+[assuming I don't know anything, how can I test what you did]
+
+## Screenshots (optional)
+[is it caught in 4k]
+
+## Anything Else?
+[you got any bonus level]


### PR DESCRIPTION
## What?
Add pull request template in the `.github` folder for easier maintenace of the repository

## Why?
For convenient and consistent practices in this repo a template will make it easier to write the description without missing anything.

## How?
According to this [docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) just added the `pull_request_template.md` file in the appropriate folder

## Testing?
From now on, when creating a PR you should be forwarded with the template, but I am afraid you're gonna have to trust me on this one since the change will only propagate once it is merged in the default branch, which is **_main_** so this will happen on the next release that we have

## Screenshots (optional)
-

## Anything Else?
nothing to add