### PR TITLE
feat: add reference to private map-service repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "map-service"]
+	path = map-service
+	url = git@github.com:eduard-balamatiuc/faf-pad-map-service.git


### PR DESCRIPTION
## What?
I added my private map-serivice as a submodule in the repostiory

## Why?
As was requested in the task of the laboratory work, each private repo should be added as a submodule to the main repo

## How?
just did a `git submodule add`

## Testing?
You should be seeing the new submodule added on the branch and not have access to it (well besides Lina)

## Screenshots (optional)
-

## Anything Else?
nothing else to add