### PR TITLE
feat: add inventory service as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,7 @@
 [submodule "lobby-service"]
 	path = lobby-service
 	url = git@github.com:eduard-balamatiuc/faf-pad-lobby-service.git
+
+[submodule "inventory-service"]
+  path = inventory-service
+  url = git@github.com:danielavornic/ghost-hunters-inventory-service.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,5 +7,5 @@
 	url = git@github.com:eduard-balamatiuc/faf-pad-lobby-service.git
 
 [submodule "inventory-service"]
-  path = inventory-service
-  url = git@github.com:danielavornic/ghost-hunters-inventory-service.git
+	path = inventory-service
+	url = git@github.com:danielavornic/ghost-hunters-inventory-service.git


### PR DESCRIPTION
## What?
Added a reference to my private repository of the inventory service as a submodule.

## Why?
To comply with the lab requirements (adding each microservice as submodule to the CPR).

## How?
I used the `git submodule` command.

## Testing?
The submodule needs to be shown as a reference folder in the repository.

## Screenshots (optional)
-

## Anything Else?
-