### PR TITLE
feat(submodule): add journal service submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 [submodule "lobby-service"]
 	path = lobby-service
 	url = git@github.com:eduard-balamatiuc/faf-pad-lobby-service.git
+[submodule "journal-service"]
+	path = journal-service
+	url = https://github.com/Ghenntoggy1/PAD-Journal-Service.git


### PR DESCRIPTION
## What?
Added Journal Service submodule linked to private repository of the Service itself.

## Why?
In order to ensure a shortcut link to the codebase of the Journal Service from the Common Public Repository.

## How?
Was used `git submodule add <repo_link> <path>` command.

## Testing?
Checkout to `feature/add-journal-service-submodule` and check the presence of new submodule - `journal-service`.

## Screenshots (optional)
<img width="1919" height="915" alt="1" src="https://github.com/user-attachments/assets/3a1b6199-eca3-4688-9053-5766b2880414" />

## Anything Else?
No.