### PR TITLE
feat(submodule): add shop service submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 [submodule "lobby-service"]
 	path = lobby-service
 	url = git@github.com:eduard-balamatiuc/faf-pad-lobby-service.git
+[submodule "shop-service"]
+	path = shop-service
+	url = https://github.com/Ghenntoggy1/PAD-Shop-Service.git


### PR DESCRIPTION
## What?
Added Shop Service submodule linked to private repository of the Service itself.

## Why?
In order to ensure existence of a shortcut link to the codebase of the Shop Service from the Common Public Repository.

## How?
Was used `git submodule add <repo_link> <path>` command.

## Testing?
Checkout to [feature/add-shop-service-submodule](https://github.com/eduard-balamatiuc/faf-pad-ghost-hunters/tree/feature/add-shop-service-submodule) and check the presence of new submodule - `shop-service`.

## Screenshots (optional)
<img width="1919" height="915" alt="image" src="https://github.com/user-attachments/assets/aa7030d9-563a-482f-8193-75d18c5e9aee" />

## Anything Else?
No.